### PR TITLE
Fixing the sheetfu.modules ModuleErrorNotFound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ sheetfu.egg-info/
 .pytest_cache/
 .coverage
 source/
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ sheetfu.egg-info/
 .coverage
 source/
 env/
+.vscode/

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ import io
 import re
 import sys
 try:
-    from setuptools import setup
+    from setuptools import setup, find_packages
 except ImportError:
-    from distutils.core import setup
+    from distutils.core import setup, find_packages
 
 
 with io.open('sheetfu/__init__.py', 'rt', encoding='utf8') as f:
@@ -24,7 +24,7 @@ except ImportError:
 
 setup(
     name='sheetfu',
-    packages=['sheetfu'],
+    packages=find_packages(),
     description='Sheetfu is a library to interact with Google sheets.',
     long_description='Sheetfu long description coming soon ...',
     version=version,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except ImportError:
 
 setup(
     name='sheetfu',
-    packages=find_packages(),
+    packages=find_packages(include=['sheetfu','sheetfu.*']),
     description='Sheetfu is a library to interact with Google sheets.',
     long_description='Sheetfu long description coming soon ...',
     version=version,


### PR DESCRIPTION
For python 3.6.5, pip installing sheetfu 0.7.0, I get an error while importing.
![image](https://user-images.githubusercontent.com/12190891/54533787-5fd59900-4961-11e9-9c65-2e77802d089f.png)

This PR addresses this, by using the find_packages() module in setuptools, it seems that it is able to correctly install the sheet.modules module.

I have tested this to the best of my current abilities.
Thanks!
