### PR TITLE
Matching sheet names ignoring case

### DIFF
--- a/sheetfu/model.py
+++ b/sheetfu/model.py
@@ -70,7 +70,7 @@ class Spreadsheet:
         :return: Sheet object matching name.
         """
         for sheet in self.sheets:
-            if sheet.name == name:
+            if sheet.name.lower() == name.lower():
                 return sheet
         else:
             raise SheetNameNoMatchError

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,6 +43,11 @@ class TestModelInstantiations:
         sheet = SpreadsheetApp(http=http_sheets_mocks).open_by_id('some_id').get_sheet_by_name('people')
         assert isinstance(sheet, Sheet)
 
+    def test_one_line_sheet_instance_different_case(self):
+        http_sheets_mocks = mock_spreadsheet_instance()
+        sheet = SpreadsheetApp(http=http_sheets_mocks).open_by_id('some_id').get_sheet_by_name('PeOpLe')
+        assert isinstance(sheet, Sheet)
+
     def test_one_line_range_instance(self):
         http_sheets_mocks = mock_spreadsheet_instance()
         sheet = SpreadsheetApp(http=http_sheets_mocks).open_by_id('some_id').get_sheet_by_name('people')


### PR DESCRIPTION
Google sheets internally ignores case for sheet names, so we should do the same.

For example, trying to create 2 sheets with the same name but different cases fails, wether you do it from the spreadsheet UI or the API.