### PR TITLE
feat(Range): Max row and max column methods at range level.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ A Simple Example
     data_range.set_background('#000000')          # set every cell backgrounds to black
     data_range.set_font_color('#ffffff')          # set every cell font colors to white
 
+    data_range.commit()                           # to commit your changes otherwise nothing gets changed.
 
 To obtain your secret json file and know more about how to initialize your ENV vars, you can refer to `the authentication tutorial`_.
 

--- a/documentation/usage.rst
+++ b/documentation/usage.rst
@@ -93,6 +93,15 @@ List of methods for **Range** object
 +-------------------------------------------------------+---------------------+
 | `commit() <usage.rst#commit - Range>`__               |                     |
 +-------------------------------------------------------+---------------------+
+| `get_row() <usage.rst#get_row>`__                     |  Integer            |
++-------------------------------------------------------+---------------------+
+| `get_column() <usage.rst#get_column>`__               |  Integer            |
++-------------------------------------------------------+---------------------+
+| `get_max_row() <usage.rst#get_max_row - Range>`__     |  Integer            |
++-------------------------------------------------------+---------------------+
+| `get_max_column() <usage.rst#get_max_column Range>`__ |  Integer            |
++-------------------------------------------------------+---------------------+
+
 
 
 SpreadsheetApp Methods
@@ -331,6 +340,39 @@ This method is particularly useful when you're not quite sure how many rows you
 have in your sheet. Under the hood, this method actually makes a request to the
 sheet and figure out the A1 notification of the range containing data.
 
+
+**get_max_row()**
+--------------------
+
+Method to return the last row in sheet. this does not necessarily means a row
+with data. An empty new sheet, typically, has 1000 rows. The method in that
+case will return 1000.
+
+.. code-block:: python
+
+    from sheetfu import SpreadsheetApp
+
+    sa = SpreadsheetApp('path/to/secret.json')
+    spreadsheet = sa.open_by_id(spreadsheet_id='<spreadsheet id>')
+    sheet = spreadsheet.get_sheet_by_name('Sheet1')
+    max_row = sheet.get_max_row()
+
+
+**get_max_column()**
+--------------------
+
+Method to return the last column in sheet. this does not necessarily means a
+column with data. An empty new sheet, typically, has 26 columns (letter Z). The
+method in that case will return 26 even if the sheet has no data.
+
+.. code-block:: python
+
+    from sheetfu import SpreadsheetApp
+
+    sa = SpreadsheetApp('path/to/secret.json')
+    spreadsheet = sa.open_by_id(spreadsheet_id='<spreadsheet id>')
+    sheet = spreadsheet.get_sheet_by_name('Sheet1')
+    max_row = sheet.get_max_column()
 
 
 Range Methods
@@ -589,3 +631,53 @@ change setters instead are batched at the range level. The commit method sends
 every batched requests at once. This means being able to make as many change as
 you want while sending only one request to the google sheet api, giving a
 significant performance boost.
+
+
+**get_row()**
+--------------------
+
+.. code-block:: python
+
+    from sheetfu import SpreadsheetApp
+
+    ss = SpreadsheetApp('path/to/secret.json').open_by_id(spreadsheet_id='<spreadsheet id>')
+    data_range = ss.get_sheet_by_name('Sheet1').get_range_from_a1('A1:B3')
+    data_range.get_row() # 1
+
+
+
+
+**get_column()**
+--------------------
+
+.. code-block:: python
+
+    from sheetfu import SpreadsheetApp
+
+    ss = SpreadsheetApp('path/to/secret.json').open_by_id(spreadsheet_id='<spreadsheet id>')
+    data_range = ss.get_sheet_by_name('Sheet1').get_range_from_a1('A1:B3')
+    data_range.get_column() # 1
+
+
+**get_max_row() - Range**
+-------------------------
+
+.. code-block:: python
+
+    from sheetfu import SpreadsheetApp
+
+    ss = SpreadsheetApp('path/to/secret.json').open_by_id(spreadsheet_id='<spreadsheet id>')
+    data_range = ss.get_sheet_by_name('Sheet1').get_range_from_a1('A1:B3')
+    data_range.get_max_row() # 3
+
+
+**get_max_column() Range**
+-------------------------
+
+.. code-block:: python
+
+    from sheetfu import SpreadsheetApp
+
+    ss = SpreadsheetApp('path/to/secret.json').open_by_id(spreadsheet_id='<spreadsheet id>')
+    data_range = ss.get_sheet_by_name('Sheet1').get_range_from_a1('A1:B3')
+    data_range.get_max_column() # 2

--- a/sheetfu/model.py
+++ b/sheetfu/model.py
@@ -662,3 +662,32 @@ class Range:
             "startColumnIndex": self.coordinates.column - 1,
             "endColumnIndex": self.coordinates.column - 1 + self.coordinates.number_of_columns
         }
+
+    def get_row(self):
+        """
+        Syntactic sugar method to return integer value of first row of range.
+        :return: int
+        """
+        return self.coordinates.row
+
+    def get_column(self):
+        """
+        Syntactic sugar method to return integer value of first column of range.
+        :return: int
+        """
+        return self.coordinates.column
+
+    def get_max_row(self):
+        """
+        Syntactic sugar method to return integer value of last row of range.
+        :return: int
+        """
+        return self.coordinates.row + self.coordinates.number_of_rows - 1
+
+    def get_max_column(self):
+        """
+        Syntactic sugar method to return integer value of last column of range.
+        :return: int
+        """
+        return self.coordinates.column + self.coordinates.number_of_columns - 1
+

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -196,3 +196,30 @@ class TestGridRange:
             range.offset(row_offset=0, column_offset=0,
                          num_rows=6, num_columns=-2)
 
+
+class TestRangeMaxRowColumn:
+
+    http_sheets_mocks = mock_spreadsheet_instance()
+    spreadsheet = SpreadsheetApp(http=http_sheets_mocks).open_by_id('some_id')
+    sheet = spreadsheet.sheets[0]
+
+    def test_max_coordinates_a1(self):
+        cell = self.sheet.get_range_from_a1('A1')
+        assert cell.get_row() == 1
+        assert cell.get_column() == 1
+        assert cell.get_max_row() == 1
+        assert cell.get_max_column() == 1
+
+    def test_max_coordinates_a1_b4(self):
+        range_ = self.sheet.get_range_from_a1('A1:B4')
+        assert range_.get_row() == 1
+        assert range_.get_column() == 1
+        assert range_.get_max_row() == 4
+        assert range_.get_max_column() == 2
+
+    def test_max_coordinates_a3_b4(self):
+        range_ = self.sheet.get_range_from_a1('B3:D4')
+        assert range_.get_row() == 3
+        assert range_.get_column() == 2
+        assert range_.get_max_row() == 4
+        assert range_.get_max_column() == 4


### PR DESCRIPTION
Added a few methods to extract the range coordinates. This is in response to the issue https://github.com/socialpoint-labs/sheetfu/issues/29 

PR covers:
- Missing documentation for get_max_row and get_max_column at sheet level.
- 4 new methods (with tests and docs) at Range level
  - get_row
  - get_column
  - get_max_row
  - get_max_column