### PR TITLE
fix(Spreadsheet): Method creating sheets now return the sheets created.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ To obtain your secret json file and know more about how to initialize your ENV v
 .. _the authentication tutorial: https://github.com/socialpoint-labs/sheetfu/blob/master/documentation/authentication.rst
 
 You can refer to the `sheetfu API documentation`_ for a more detailed description.
+
 .. _sheetfu API documentation: https://github.com/socialpoint-labs/sheetfu/blob/master/documentation/usage.rst
 
 The Table module

--- a/documentation/usage.rst
+++ b/documentation/usage.rst
@@ -212,14 +212,10 @@ Spreadsheet Methods
 
     sa = SpreadsheetApp('path/to/secret.json')
     spreadsheet = sa.open_by_id(spreadsheet_id='<spreadsheet id>')
-    spreadsheet.create_sheets(['my_first_sheet', 'my_second_sheet'])
+    new_sheets = spreadsheet.create_sheets(['my_first_sheet', 'my_second_sheet'])
 
-    # The 2 new sheets will be added as Sheet objects to the sheets attributes.
-
-    my_first_sheet = spreadsheet.get_sheet_by_name('my_first_sheet')
-    my_second_sheet = spreadsheet.get_sheet_by_name('my_second_sheet')
-
-
+It returns a list of Sheet objects in the same order of the new sheet names
+list given as parameter.
 
 **duplicate_sheet()**
 ---------------------
@@ -231,11 +227,12 @@ Spreadsheet Methods
 
     sa = SpreadsheetApp('path/to/secret.json')
     spreadsheet = sa.open_by_id(spreadsheet_id='<spreadsheet id>')
-    spreadsheet.duplicate_sheet(
+    cloned_sheet = spreadsheet.duplicate_sheet(
         new_sheet_name='cloned name',
         sheet_name='original sheet'
     )
-    cloned_sheet = spreadsheet.get_sheet_by_name('cloned name')
+`cloned_sheet` in that case will return the Sheet object of the new cloned
+sheet.
 
 
 **commit() - Spreadsheet**

--- a/sheetfu/model.py
+++ b/sheetfu/model.py
@@ -69,6 +69,7 @@ class Spreadsheet:
         :param name: name of the sheet we want to access.
         :return: Sheet object matching name.
         """
+        print(self.sheets)
         for sheet in self.sheets:
             if sheet.name.lower() == name.lower():
                 return sheet
@@ -127,6 +128,7 @@ class Spreadsheet:
             body=body
         ).execute()
         self._add_sheets_from_response(response=response, reply_type="addSheet")
+        return [self.get_sheet_by_name(name) for name in sheet_names]
 
     def duplicate_sheet(self, new_sheet_name, sheet_id=None, sheet_name=None):
         """
@@ -154,6 +156,7 @@ class Spreadsheet:
             body=body
         ).execute()
         self._add_sheets_from_response(response=response, reply_type="duplicateSheet")
+        return self.get_sheet_by_name(new_sheet_name)
 
     def commit(self):
         if len(self.batches) == 0:

--- a/sheetfu/model.py
+++ b/sheetfu/model.py
@@ -69,7 +69,6 @@ class Spreadsheet:
         :param name: name of the sheet we want to access.
         :return: Sheet object matching name.
         """
-        print(self.sheets)
         for sheet in self.sheets:
             if sheet.name.lower() == name.lower():
                 return sheet

--- a/tests/fixtures/duplicate_sheets.json
+++ b/tests/fixtures/duplicate_sheets.json
@@ -5,7 +5,7 @@
          "duplicateSheet":{
             "properties":{
                "sheetId":1957647368,
-               "title":"random2",
+               "title":"cloned_sheet",
                "index":0,
                "sheetType":"GRID",
                "gridProperties":{

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -202,7 +202,7 @@ class TestSheetCreationMethodReturns:
     http_sheets_mocks = mock_spreadsheet_instance(["add_sheets.json", "duplicate_sheets.json"])
     spreadsheet = SpreadsheetApp(http=http_sheets_mocks).open_by_id('some_id')
 
-    def test_create_sheets(self):
+    def test_create_sheets_types(self):
         new_sheets = self.spreadsheet.create_sheets(["test_sheet", "test_sheet_2"])
         assert isinstance(new_sheets, list)
         assert isinstance(new_sheets[0], Sheet)
@@ -210,9 +210,8 @@ class TestSheetCreationMethodReturns:
         assert isinstance(new_sheets[1], Sheet)
         assert new_sheets[1].name == 'test_sheet_2'
 
-    def test_duplicate_sheet(self):
+    def test_duplicate_sheet_type(self):
         # Important! This test needs to be executed after test_create_sheets, as it clones that sheet #
         duplicated_sheet = self.spreadsheet.duplicate_sheet(new_sheet_name="cloned_sheet", sheet_name="test_sheet")
-        print(duplicated_sheet)
         assert isinstance(duplicated_sheet, Sheet)
         assert duplicated_sheet.name == 'cloned_sheet'

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -196,3 +196,23 @@ class TestGridRange:
             range.offset(row_offset=0, column_offset=0,
                          num_rows=6, num_columns=-2)
 
+
+class TestSheetCreationMethodReturns:
+
+    http_sheets_mocks = mock_spreadsheet_instance(["add_sheets.json", "duplicate_sheets.json"])
+    spreadsheet = SpreadsheetApp(http=http_sheets_mocks).open_by_id('some_id')
+
+    def test_create_sheets(self):
+        new_sheets = self.spreadsheet.create_sheets(["test_sheet", "test_sheet_2"])
+        assert isinstance(new_sheets, list)
+        assert isinstance(new_sheets[0], Sheet)
+        assert new_sheets[0].name == 'test_sheet'
+        assert isinstance(new_sheets[1], Sheet)
+        assert new_sheets[1].name == 'test_sheet_2'
+
+    def test_duplicate_sheet(self):
+        # Important! This test needs to be executed after test_create_sheets, as it clones that sheet #
+        duplicated_sheet = self.spreadsheet.duplicate_sheet(new_sheet_name="cloned_sheet", sheet_name="test_sheet")
+        print(duplicated_sheet)
+        assert isinstance(duplicated_sheet, Sheet)
+        assert duplicated_sheet.name == 'cloned_sheet'


### PR DESCRIPTION
PR in response to https://github.com/socialpoint-labs/sheetfu/issues/27.

Now duplicate_sheet and create_sheets methods returns the sheets created.