### PR TITLE
Adding custom error when using row=0 or column=0

### DIFF
--- a/sheetfu/exceptions.py
+++ b/sheetfu/exceptions.py
@@ -19,3 +19,7 @@ class SheetIdNoMatchError(Exception):
 class NoDataRangeError(Exception):
     """No data found in target sheet."""
     pass
+
+
+class RowOrColumnEqualsZeroError(Exception):
+    """Row or Column index starts at 1, not 0"""

--- a/sheetfu/model.py
+++ b/sheetfu/model.py
@@ -11,7 +11,9 @@
 
 
 from sheetfu.helpers import convert_a1_to_coordinates, convert_coordinates_to_a1, append_sheet_name
-from sheetfu.exceptions import SheetNameNoMatchError, SheetIdNoMatchError, NoDataRangeError, SizeNotMatchingException
+from sheetfu.exceptions import (
+    SheetNameNoMatchError, SheetIdNoMatchError, NoDataRangeError, SizeNotMatchingException, RowOrColumnEqualsZeroError
+)
 from sheetfu.parsers import CellParsers
 
 
@@ -201,6 +203,10 @@ class Sheet:
         :param number_of_column: Number of columns in the target range.
         :return: Range object.
         """
+        if row == 0 or column == 0:
+            raise RowOrColumnEqualsZeroError(
+                "Row and column parameters can not be equal to 0. The cell A1 is row=1 and column=1"
+            )
         a1 = convert_coordinates_to_a1(row, column, number_of_row, number_of_column)
         return Range(
             client=self.client,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,5 @@
 from sheetfu.client import SpreadsheetApp
+from sheetfu.exceptions import RowOrColumnEqualsZeroError
 from sheetfu.model import Spreadsheet, Sheet, Range
 from tests.utils import mock_range_instance, mock_spreadsheet_instance, mock_google_sheets_responses
 from tests.utils import open_fixture
@@ -224,8 +225,7 @@ class TestRangeMaxRowColumn:
         assert range_.get_max_row() == 4
         assert range_.get_max_column() == 4
 
-        
-        
+
 class TestSheetCreationMethodReturns:
 
     http_sheets_mocks = mock_spreadsheet_instance(["add_sheets.json", "duplicate_sheets.json"])
@@ -244,3 +244,24 @@ class TestSheetCreationMethodReturns:
         duplicated_sheet = self.spreadsheet.duplicate_sheet(new_sheet_name="cloned_sheet", sheet_name="test_sheet")
         assert isinstance(duplicated_sheet, Sheet)
         assert duplicated_sheet.name == 'cloned_sheet'
+
+
+class TestWrongRowAndColumnValues:
+    http_sheets_mocks = mock_range_instance()
+
+    client = SpreadsheetApp(http=http_sheets_mocks)
+    spreadsheet = client.open_by_id('some_id')
+    sheet = spreadsheet.get_sheet_by_name("people")
+
+    def test_invalid_row(self):
+        with pytest.raises(RowOrColumnEqualsZeroError):
+            self.sheet.get_range(row=0, column=1)
+
+    def test_invalid_column(self):
+        with pytest.raises(RowOrColumnEqualsZeroError):
+            self.sheet.get_range(row=1, column=0)
+
+    def test_invalid_row_and_column(self):
+        with pytest.raises(RowOrColumnEqualsZeroError):
+            self.sheet.get_range(row=0, column=0)
+


### PR DESCRIPTION
Simple custom error when row and column are equal to zero. get_range expects values starting from 1. 
In google sheets, the cell A1 is considered row=1 and column=1.