### PR TITLE
fix(travis): Update supported python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty
 language: python
 python:
 - '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ dist: trusty
 language: python
 python:
 - '2.7'
-- '3.4'
-- '3.5'
 - '3.6'
+- '3.7'
+- '3.8'
 install: pip install -r requirements_dev.txt
 script: py.test
 jobs:


### PR DESCRIPTION
Python 3.4 & 3.5 are at the end of their lifecycle, and some of our dependencies no longer support them.